### PR TITLE
Module support fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "FLIP",
   "version": "0.1.9",
   "description": "A FLIP helper",
-  "main": "index.js",
+  "main": "dist/flip.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Allows for `import "FLIP"` in Webpack and other module systems.
